### PR TITLE
Small input optimization

### DIFF
--- a/museair.cpp
+++ b/museair.cpp
@@ -304,8 +304,9 @@ static FORCE_INLINE void tower_short(const uint8_t* bytes,
     } else {
         *i = read_u64<bswap>(bytes + seg(0));
         *j = read_u64<bswap>(bytes + seg(1));
-        uint64_t lo0, hi0, p = read_u64<bswap>(bytes + len - seg(2));
-        uint64_t lo1, hi1, q = read_u64<bswap>(bytes + len - seg(1));
+        uint64_t lo0, hi0, p;
+        uint64_t lo1, hi1, q;
+        read_short<bswap>(bytes+seg(2), len+seg(2), &p, &q);
         MathMult::mult64_128(lo0, hi0, DEFAULT_SECRET[2], p ^ DEFAULT_SECRET[3]);
         MathMult::mult64_128(lo1, hi1, DEFAULT_SECRET[4], q ^ DEFAULT_SECRET[5]);
         *i ^= lo ^ lo0 ^ hi1;


### PR DESCRIPTION
My experiment on small input optimization looks good, all variants pass SMHasher3. So I think it worth to let you know it.

[MuseAir.log](https://github.com/user-attachments/files/17177560/MuseAir.log)
[MuseAir-128.log](https://github.com/user-attachments/files/17177561/MuseAir-128.log)
[MuseAir-BFast.log](https://github.com/user-attachments/files/17177562/MuseAir-BFast.log)
[MuseAir-BFast-128.log](https://github.com/user-attachments/files/17177563/MuseAir-BFast-128.log)

Note:
1. there seems a timer bug in SMHasher3 on macOS, resulting in 100x speed and throughput measured in the logs.
2. the verification test was disabled temporary